### PR TITLE
Support non-default 'pi' user for qmi_install.sh

### DIFF
--- a/tutorials/QMI_tutorial/qmi_install.sh
+++ b/tutorials/QMI_tutorial/qmi_install.sh
@@ -12,7 +12,7 @@ YELLOW='\033[1;33m'
 RED='\033[0;31m'
 SET='\033[0m'
 
-DIR=/home/pi/files
+DIR=/home/$SUDO_USER/files
 UDHCPC_DIR=/usr/share/udhcpc
 
 echo "${YELLOW}Clean Old Files${SET}"
@@ -20,8 +20,8 @@ if [ -d $DIR ]; then
     rm -rf $DIR
     rm -rf $DIR.zip ; fi # for old directory
 
-echo "${YELLOW}Change directory to /home/pi${SET}"
-cd /home/pi
+echo "${YELLOW}Change directory to /home/${SUDO_USER}${SET}"
+cd /home/SUDO_USER
 
 echo "${YELLOW}Downloading source files${SET}"
 wget https://github.com/sixfab/Sixfab_RPi_3G-4G-LTE_Base_Shield/raw/master/tutorials/QMI_tutorial/src/quectel-CM.zip -O quectel-CM.zip


### PR DESCRIPTION
Use `$SUDO_USER` instead of hard-coded `pi` for directory references in order to handle environments that have changed from the default `pi` user.